### PR TITLE
Fixes Ugly Empty Scrollbar

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" style="overflow-y: auto;">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">


### PR DESCRIPTION
I think this commit should fix an issue where a vertical scrollbar cutout shows regardless of whether content should be scrollable (basically an empty white bar at the right side), but a scrollbar still shows if there is content that needs scrolling. The `chunk-vendors.--------.css` file (Vuetify?) is adding an `overflow-y: scroll;` to `html`, which is now overridden in this commit (I think).

I tested the CSS override in the client app but not based on running a local instance from the repo, although it's probably fine since the CSS rule doesn't change any functional logic of the app.